### PR TITLE
Change capitalization of template group headings

### DIFF
--- a/lib/document.rb
+++ b/lib/document.rb
@@ -37,11 +37,11 @@ module Jobless
     end
 
     def open_source(&block)
-      group("Open source", :open_source, &block)
+      group("Open Source", :open_source, &block)
     end
 
     def other_experience(&block)
-      group("Other experience", :other_experience, &block)
+      group("Other Experience", :other_experience, &block)
     end
 
     def template(template)

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -75,7 +75,7 @@ describe Jobless::Document do
   describe '#open_source' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Open source", :open_source).and_yield
+        with("Open Source", :open_source).and_yield
       document.open_source do
       end
     end
@@ -84,7 +84,7 @@ describe Jobless::Document do
   describe '#other_experience' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Other experience", :other_experience).and_yield
+        with("Other Experience", :other_experience).and_yield
       document.other_experience do
       end
     end


### PR DESCRIPTION
Headings should really be capitalized, so 'Other experience' now reads 'Other Experience' and 'Open source' now reads 'Open Source'. The corresponding tests are updated accordingly.
