### PR TITLE
Cleanup

### DIFF
--- a/jobless.gemspec
+++ b/jobless.gemspec
@@ -14,5 +14,7 @@ Gem::Specification.new do |s|
                    'lib/template/template.html.erb']
   s.homepage    = 'https://github.com/dabrorius/jobless'
   s.license     = 'MIT'
+
+  s.add_runtime_dependency 'activesupport'
 end
 

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -1,4 +1,5 @@
 require 'erb'
+require 'active_support/core_ext/string/inflections'
 
 module Jobless
   class Document

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -37,20 +37,10 @@ module Jobless
       @groups.push group
     end
 
-    def employment(&block)
-      group("Employment", &block)
-    end
-
-    def education(&block)
-      group("Education", &block)
-    end
-
-    def open_source(&block)
-      group("Open Source", &block)
-    end
-
-    def other_experience(&block)
-      group("Other Experience", &block)
+    %w(employment education open_source other_experience).each do |group_name|
+      define_method(group_name) do |&block|
+        group(group_name.titleize, &block)
+      end
     end
 
     def template(template)

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -13,6 +13,13 @@ module Jobless
       homepage
     )
 
+    GROUP_NAMES = %w(
+      employment
+      education
+      open_source
+      other_experience
+    )
+
     def initialize
       @data = {}
       @groups = []
@@ -36,8 +43,8 @@ module Jobless
       group.instance_eval &block
       @groups.push group
     end
-
-    %w(employment education open_source other_experience).each do |group_name|
+    
+    GROUP_NAMES.each do |group_name|
       define_method(group_name) do |&block|
         group(group_name.titleize, &block)
       end

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -4,6 +4,14 @@ module Jobless
   class Document
     attr_reader :groups, :data
 
+    PERSONAL_ATTRIBUTES = %w(
+      name
+      email
+      location
+      address
+      homepage
+    )
+
     def initialize
       @data = {}
       @groups = []
@@ -12,7 +20,7 @@ module Jobless
     end
 
     # Define methods for setting personal data
-    %w(name location address homepage email).each do |attribute_name|
+    PERSONAL_ATTRIBUTES.each do |attribute_name|
       define_method(attribute_name) do |attribute=nil|
         if attribute
           @data[attribute_name.to_sym] = attribute

--- a/lib/document.rb
+++ b/lib/document.rb
@@ -30,26 +30,26 @@ module Jobless
       end
     end
 
-    def group(name, type=nil, &block)
-      group = Group.new(name, type)
+    def group(name, &block)
+      group = Group.new(name)
       group.instance_eval &block
       @groups.push group
     end
 
     def employment(&block)
-      group("Employment", :employment, &block)
+      group("Employment", &block)
     end
 
     def education(&block)
-      group("Education", :education, &block)
+      group("Education", &block)
     end
 
     def open_source(&block)
-      group("Open Source", :open_source, &block)
+      group("Open Source", &block)
     end
 
     def other_experience(&block)
-      group("Other Experience", :other_experience, &block)
+      group("Other Experience", &block)
     end
 
     def template(template)

--- a/lib/group.rb
+++ b/lib/group.rb
@@ -1,10 +1,12 @@
+require 'active_support/core_ext/string/inflections'
+
 module Jobless
   class Group
     attr_reader :items, :name, :type
 
     def initialize(name)
       @name = name
-      @type = name.downcase.gsub(/([^a-z0-9_]|\s)+/i, '-').gsub(/^-|-$/i, '')
+      @type = name.parameterize
       @items = []
     end
 

--- a/lib/group.rb
+++ b/lib/group.rb
@@ -2,9 +2,9 @@ module Jobless
   class Group
     attr_reader :items, :name, :type
 
-    def initialize(name, type=nil)
+    def initialize(name)
       @name = name
-      @type = type
+      @type = name.downcase.gsub(/([^a-z0-9_]|\s)+/i, '-').gsub(/^-|-$/i, '')
       @items = []
     end
 

--- a/lib/item.rb
+++ b/lib/item.rb
@@ -2,13 +2,23 @@ module Jobless
   class Item
     attr_reader :data, :bulletins
 
+    PERSONAL_ATTRIBUTES = %w(
+      title
+      company
+      homepage
+      technologies
+      description
+      start_date
+      end_date
+    )
+
     def initialize
       @data = {}
       @bulletins = []
     end
 
     # Define methods for setting personal data
-    %w(title company homepage technologies description start_date end_date).each do |attribute_name|
+    PERSONAL_ATTRIBUTES.each do |attribute_name|
       define_method(attribute_name) do |attribute=nil|
         if attribute
           @data[attribute_name.to_sym] = attribute

--- a/spec/document_spec.rb
+++ b/spec/document_spec.rb
@@ -57,7 +57,7 @@ describe Jobless::Document do
   describe '#employment' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Employment", :employment).and_yield
+        with("Employment").and_yield
       document.employment do
       end
     end
@@ -66,7 +66,7 @@ describe Jobless::Document do
   describe '#education' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Education", :education).and_yield
+        with("Education").and_yield
       document.education do
       end
     end
@@ -75,7 +75,7 @@ describe Jobless::Document do
   describe '#open_source' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Open Source", :open_source).and_yield
+        with("Open Source").and_yield
       document.open_source do
       end
     end
@@ -84,7 +84,7 @@ describe Jobless::Document do
   describe '#other_experience' do
     it 'calls #group with appropriate parameters' do
       expect(document).to receive(:group).
-        with("Other Experience", :other_experience).and_yield
+        with("Other Experience").and_yield
       document.other_experience do
       end
     end

--- a/spec/group_spec.rb
+++ b/spec/group_spec.rb
@@ -2,7 +2,13 @@ require 'group'
 require 'item'
 
 describe Jobless::Group do
-  let(:group) { Jobless::Group.new("Experience") }
+  subject(:group) { Jobless::Group.new("Other experience") }
+
+  describe '#initialize' do
+    context 'infers type from name' do
+      it { expect(group.type).to eq('other-experience') }
+    end
+  end
 
   describe '#item' do
     it 'creates a new item' do


### PR DESCRIPTION
I've made some pre-refactoring before projects implementation. Because employee can work on the several projects in the same company, it's reasonable allow to specify projects per company in CV. For this feature we need to introduce groups in the form of the tree, where one node can contain many other nodes. In this case we can write something like this:

``` ruby
employment do
    company "Dream" do
      homepage "http://dream.com/"

      project "A" do
        homepage "http://project-a.com/"

        title "Rails developer"

        technologies "Ruby, Ruby on Rails"

        bulletin "B1."
        bulletin "B2."

        start_date "June 2015"
        end_date "Current"
      end

      project "B" do
        homepage "http://project-b.com/"

        title "JavaScript developer"

        technologies "Javascript, Ruby on Rails"

        bulletin "B3."
        bulletin "B4."

        start_date "June 2014"
        end_date "June 2015"
      end
    end
  end
end
```
